### PR TITLE
Update javarosa version to 3.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     exclude group: 'commons-logging'
   }
   compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-  compile(group: 'org.getodk', name: 'javarosa', version: '2.17.2') {
+  compile(group: 'org.getodk', name: 'javarosa', version: '3.1.0') {
     exclude group: 'org.slf4j'
   }
   compile group: 'org.hsqldb', name: 'hsqldb', version: '2.4.0'


### PR DESCRIPTION
Fixed https://github.com/onaio/zebra/issues/7910
Updates javarosa dependency version to v3.1.0
